### PR TITLE
Force user to select an institution when registering

### DIFF
--- a/spec/features/devise/confirmation_email_spec.rb
+++ b/spec/features/devise/confirmation_email_spec.rb
@@ -2,7 +2,10 @@ require 'spec_helper'
 require 'support/feature_helpers'
 
 feature "Confirmation email" do
-  let(:attrs) { FactoryGirl.attributes_for(:user).slice(:username, :_full_name, :email, :password) }
+  let(:attrs) { FactoryGirl.attributes_for(:user)
+      .slice(:username, :_full_name, :email, :password)
+      .merge(institution_id: FactoryGirl.create(:institution).id)
+  }
 
   # devise triggers callbacks to send emails that will not be triggered if using
   # transactions, so use truncation instead

--- a/spec/features/site/flag_require_registration_approval_spec.rb
+++ b/spec/features/site/flag_require_registration_approval_spec.rb
@@ -4,7 +4,12 @@ require 'support/feature_helpers'
 include ActionView::Helpers::SanitizeHelper
 
 feature 'Behaviour of the flag Site#require_registration_approval' do
-  let(:attrs) { FactoryGirl.attributes_for(:user).slice(:username, :_full_name, :email, :password) }
+  let(:user) { FactoryGirl.create(:user) }
+  let!(:attrs) {
+    FactoryGirl.attributes_for(:user)
+      .slice(:username, :_full_name, :email, :password)
+      .merge!(institution_id: FactoryGirl.create(:institution).id)
+  }
 
   context "if admin approval is required" do
     before {
@@ -14,6 +19,7 @@ feature 'Behaviour of the flag Site#require_registration_approval' do
     context "registering in the website" do
       before {
         Site.current.update_attributes(events_enabled: false)
+        Institution.last.add_member! user, "Admin"
 
         with_resque do
           expect { register_with(attrs) }.to change{ User.count }.by(1)
@@ -30,10 +36,10 @@ feature 'Behaviour of the flag Site#require_registration_approval' do
         mail.body.encoded.should match(t('devise.mailer.confirmation_instructions.confirmation_pending'))
       end
 
-      it "sends an email to all admins", with_truncation: true do
+      it "sends an email to all institution admins", with_truncation: true do
         mail = email_by_subject t('admin_mailer.new_user_waiting_for_approval.subject')
         mail.should_not be_nil
-        mail.to.should eql([User.where(superuser: true).first.email])
+        mail.to.should eql([user.email])
       end
 
       context "shows the pending approval page" do

--- a/spec/features/visitor_logs_in_spec.rb
+++ b/spec/features/visitor_logs_in_spec.rb
@@ -125,6 +125,7 @@ feature 'Visitor logs in' do
 
     scenario 'after a failed registration (/users)' do
       visit register_path
+      fill_in 'user[institution_id]', with: @user.institution.id
       click_button 'Register'
       expect(current_path).to eq("/users")
 
@@ -219,6 +220,7 @@ feature 'Visitor logs in' do
       Site.current.update_attributes(require_registration_approval: true)
 
       attrs = FactoryGirl.attributes_for(:user)
+      attrs.merge!(institution_id: FactoryGirl.create(:institution).id)
       register_with attrs
       expect(current_path).to eq(my_approval_pending_path)
 

--- a/spec/features/visitor_signs_up_spec.rb
+++ b/spec/features/visitor_signs_up_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 require 'support/feature_helpers'
 
 feature 'Visitor signs up' do
+  let(:institution) { FactoryGirl.create(:institution) }
 
   scenario 'with valid email and password' do
-    attrs = FactoryGirl.attributes_for(:user)
+    attrs = FactoryGirl.attributes_for(:user, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(my_home_path)
@@ -15,7 +16,7 @@ feature 'Visitor signs up' do
   end
 
   scenario 'with invalid email' do
-    attrs = FactoryGirl.attributes_for(:user, email: "invalid_email")
+    attrs = FactoryGirl.attributes_for(:user, email: "invalid_email", institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -24,7 +25,7 @@ feature 'Visitor signs up' do
   end
 
   scenario 'with blank password' do
-    attrs = FactoryGirl.attributes_for(:user, password: nil)
+    attrs = FactoryGirl.attributes_for(:user, password: nil, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -33,7 +34,16 @@ feature 'Visitor signs up' do
   end
 
   scenario 'with blank name' do
-    attrs = FactoryGirl.attributes_for(:user, _full_name: nil)
+    attrs = FactoryGirl.attributes_for(:user, _full_name: nil, institution_id: "")
+    register_with attrs
+
+    current_path.should eq(register_path)
+    has_field_with_error "user_institution_id"
+    expect(page).to have_content('Sign in')
+  end
+
+  scenario 'with blank institution' do
+    attrs = FactoryGirl.attributes_for(:user, _full_name: nil, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -43,7 +53,7 @@ feature 'Visitor signs up' do
 
   scenario 'with the email of another user' do
     another_user = FactoryGirl.create(:user)
-    attrs = FactoryGirl.attributes_for(:user, email: another_user.email)
+    attrs = FactoryGirl.attributes_for(:user, email: another_user.email, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -52,7 +62,7 @@ feature 'Visitor signs up' do
 
   scenario 'with the email of a disabled user' do
     disabled_user = FactoryGirl.create(:user, disabled: true)
-    attrs = FactoryGirl.attributes_for(:user, email: disabled_user.email)
+    attrs = FactoryGirl.attributes_for(:user, email: disabled_user.email, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -61,7 +71,7 @@ feature 'Visitor signs up' do
 
   scenario 'with the username of another user' do
     another_user = FactoryGirl.create(:user)
-    attrs = FactoryGirl.attributes_for(:user, username: another_user.username)
+    attrs = FactoryGirl.attributes_for(:user, username: another_user.username, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -70,7 +80,7 @@ feature 'Visitor signs up' do
 
   scenario 'with the username of a disabled user' do
     disabled_user = FactoryGirl.create(:user)
-    attrs = FactoryGirl.attributes_for(:user, username: disabled_user.username)
+    attrs = FactoryGirl.attributes_for(:user, username: disabled_user.username, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -79,7 +89,7 @@ feature 'Visitor signs up' do
 
   scenario "with the username equal to some space's permalink" do
     space = FactoryGirl.create(:space)
-    attrs = FactoryGirl.attributes_for(:user, username: space.permalink)
+    attrs = FactoryGirl.attributes_for(:user, username: space.permalink, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -88,7 +98,7 @@ feature 'Visitor signs up' do
 
   scenario "with the username equal to some disabled space's permalink" do
     disabled_space = FactoryGirl.create(:space, disabled: true)
-    attrs = FactoryGirl.attributes_for(:user, username: disabled_space.permalink)
+    attrs = FactoryGirl.attributes_for(:user, username: disabled_space.permalink, institution_id: institution.id)
     register_with attrs
 
     current_path.should eq(user_registration_path)
@@ -96,7 +106,7 @@ feature 'Visitor signs up' do
   end
 
   scenario "when the password confirmation doesn't match" do
-    attrs = FactoryGirl.attributes_for(:user)
+    attrs = FactoryGirl.attributes_for(:user, institution_id: institution.id)
     attrs[:password_confirmation] = "#{attrs[:password]}-2"
     register_with attrs
 
@@ -105,7 +115,7 @@ feature 'Visitor signs up' do
   end
 
   scenario "send invalid register form and try to change language after" do
-    attrs = { email: "", _full_name: "", password: "" }
+    attrs = { email: "", _full_name: "", password: "", institution_id: "" }
     register_with attrs
     click_link I18n.t('locales.en')
 


### PR DESCRIPTION
When register in site is available and a users try to register himself him should be forced to select an institution. To guarantee this, a verifying method was made inside the registrations controller. Making the verification this way ensure that administrators can continue creating users without institution.

refs #1352
