### PR TITLE
Changed the find_by_param method to find_by! because find_by returns nil...

### DIFF
--- a/app/controllers/custom_bigbluebutton_rooms_controller.rb
+++ b/app/controllers/custom_bigbluebutton_rooms_controller.rb
@@ -13,19 +13,19 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
   # For :join and :end we need information from the web conference server, so we have to fetch it.
   # This has to run before any kind of authorization because some methods need this extra
   # information, see `ApplicationController.bigbluebutton_role`.
-  load_resource :find_by => :param, :class => "BigbluebuttonRoom",
-    :instance_name => "room", :except => [:join, :end]
-  prepend_before_action :load_and_fetch_room_info, :only => [:join, :end]
+  load_resource find_by: :param, class: "BigbluebuttonRoom",
+    instance_name: "room", except: [:join, :end]
+  prepend_before_action :load_and_fetch_room_info, only: [:join, :end]
 
   # Authorizing is the same for all actions
-  authorize_resource :class => "BigbluebuttonRoom", :instance_name => "room"
+  authorize_resource class: "BigbluebuttonRoom", instance_name: "room"
 
   # the logic of the 2-step joining process
-  before_filter :check_redirect_to_invite, :only => [:invite_userid]
-  before_filter :check_redirect_to_invite_userid, :only => [:invite]
+  before_filter :check_redirect_to_invite, only: [:invite_userid]
+  before_filter :check_redirect_to_invite_userid, only: [:invite]
 
   # don't let users join if the room's limit was exceeded
-  before_filter :check_user_limit, :only => [:join]
+  before_filter :check_user_limit, only: [:join]
 
   layout :determine_layout
 
@@ -54,7 +54,7 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
     if user_signed_in?
       redirect_to invite_bigbluebutton_room_path(@room)
     elsif has_user_param
-      redirect_to invite_bigbluebutton_room_path(@room, :user => { :name => params[:user][:name] })
+      redirect_to invite_bigbluebutton_room_path(@room, user: { name: params[:user][:name] })
     end
   end
 
@@ -83,7 +83,7 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
   def invitation
     respond_to do |format|
       format.html {
-        render :layout => false if request.xhr?
+        render layout: false if request.xhr?
       }
     end
   end
@@ -99,14 +99,14 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
 
     else
       invitation_params = {
-        :sender => current_user,
-        :target => @room,
-        :starts_on => params[:invite][:starts_on],
-        :ends_on => params[:invite][:ends_on],
-        :title => params[:invite][:title],
-        :url => join_webconf_url(@room),
-        :description => params[:invite][:message],
-        :ready => true
+        sender: current_user,
+        target: @room,
+        starts_on: params[:invite][:starts_on],
+        ends_on: params[:invite][:ends_on],
+        title: params[:invite][:title],
+        url: join_webconf_url(@room),
+        description: params[:invite][:message],
+        ready: true
       }
 
       # creates an invitation for each user
@@ -116,7 +116,7 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
         if user.is_a? String
           invitation_params[:recipient_email] = user
         else
-          invitation_params[:recipient] = User.find_by_id(user)
+          invitation_params[:recipient] = User.find_by(id: user)
         end
         invitations << WebConferenceInvitation.create(invitation_params)
       end
@@ -139,7 +139,7 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
 
   # Loads the room and fetches information from the web conference server.
   def load_and_fetch_room_info
-    @room = BigbluebuttonRoom.find_by_param(params[:id])
+    @room = BigbluebuttonRoom.find_by!(param: params[:id])
     @room.fetch_is_running?
     @room.fetch_meeting_info if @room.is_running?
   end

--- a/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
+++ b/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
@@ -371,7 +371,7 @@ describe CustomBigbluebuttonRoomsController do
           let(:room) { user.bigbluebutton_room }
           before {
             login_as(user)
-            BigbluebuttonRoom.stub(:find_by_param) { room }
+            BigbluebuttonRoom.stub(:find_by!) { room }
             controller.should_receive(:check_user_limit) { true }
           }
 
@@ -401,7 +401,7 @@ describe CustomBigbluebuttonRoomsController do
           let(:room) { user.bigbluebutton_room }
           before {
             login_as(user)
-            BigbluebuttonRoom.should_receive(:find_by_param).once { room }
+            BigbluebuttonRoom.should_receive(:find_by!).once { room }
             controller.should_receive(:bigbluebutton_role).with(room) { :moderator }
             controller.should_receive(:check_user_limit) { true }
             room.stub(:is_running?) { true }
@@ -426,7 +426,7 @@ describe CustomBigbluebuttonRoomsController do
             before :each do
               login_as(user)
               request.env["HTTP_REFERER"] = "/any"
-              BigbluebuttonRoom.stub(:find_by_param) { room }
+              BigbluebuttonRoom.stub(:find_by!) { room }
 
               # to guide the behavior of #join, copied from the tests in BigbluebuttonRails
               room.should_receive(:fetch_is_running?).at_least(:once).and_return(false)
@@ -446,7 +446,7 @@ describe CustomBigbluebuttonRoomsController do
               another_user = FactoryGirl.create(:user)
               login_as(another_user)
               request.env["HTTP_REFERER"] = "/any"
-              BigbluebuttonRoom.stub(:find_by_param) { room }
+              BigbluebuttonRoom.stub(:find_by!) { room }
               BigbluebuttonRoom.any_instance.stub(:fetch_is_running?) { false }
 
               # to guide the behavior of #join, copied from the tests in BigbluebuttonRails
@@ -468,7 +468,7 @@ describe CustomBigbluebuttonRoomsController do
             let(:room) { user.bigbluebutton_room }
             before {
               login_as(user)
-              BigbluebuttonRoom.stub(:find_by_param).and_return(room)
+              BigbluebuttonRoom.stub(:find_by!).and_return(room)
               controller.should_receive(:bigbluebutton_role).with(room) { :moderator }
               room.stub(:is_running?).and_return(true)
               room.stub(:fetch_is_running?).and_return(true)
@@ -496,7 +496,7 @@ describe CustomBigbluebuttonRoomsController do
 
             before do
               request.env["HTTP_REFERER"] = referer
-              BigbluebuttonRoom.stub(:find_by_param) { room }
+              BigbluebuttonRoom.stub(:find_by!) { room }
             end
 
             context "doesn't check the limit when creating the room" do
@@ -576,7 +576,7 @@ describe CustomBigbluebuttonRoomsController do
 
             before do
               request.env["HTTP_REFERER"] = referer
-              BigbluebuttonRoom.stub(:find_by_param) { room }
+              BigbluebuttonRoom.stub(:find_by!) { room }
               space.add_member!(user, 'Admin')
             end
 
@@ -664,7 +664,7 @@ describe CustomBigbluebuttonRoomsController do
       let(:room) { user.bigbluebutton_room }
       before {
         login_as(user)
-        BigbluebuttonRoom.stub(:find_by_param) { room }
+        BigbluebuttonRoom.stub(:find_by!) { room }
       }
 
       context "when a meeting is running" do
@@ -693,7 +693,7 @@ describe CustomBigbluebuttonRoomsController do
       let(:room) { user.bigbluebutton_room }
       before {
         login_as(user)
-        BigbluebuttonRoom.should_receive(:find_by_param).once { room }
+        BigbluebuttonRoom.should_receive(:find_by!).once { room }
         room.stub(:is_running?) { true }
         room.should_receive(:fetch_is_running?).at_least(:once) { true }
         room.should_receive(:fetch_meeting_info).once {


### PR DESCRIPTION
Changed the "find_by_param" method to "find_by!" because "find_by" returns nil when record is not found, while the return of "find_by!" is "record not found".

refs #1399
