### PR TITLE
Bug's #1588 #1589 - Creating users when the institution is full

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -236,7 +236,8 @@ class UsersController < ApplicationController
 
     if @user.save
       @user.confirm!
-      @user.approve!
+      ignore_full = can?(:approve_when_full, @user)
+      @user.approve!(ignore_full)
       flash[:success] = t("users.create.success")
       respond_to do |format|
         format.html { redirect_to manage_users_path }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -232,13 +232,19 @@ class UsersController < ApplicationController
 
     # When an institutional admin is creating a user, the user created will always belong
     # to his institution
-    @user.institution = current_user.institution if is_institution_admin?
+    if is_institution_admin?
+      @user.institution = current_user.institution
+      if current_user.institution.can_record_full?
+        @user.can_record = false
+        msg = t('manage.users.create_without_record')
+      end
+    end
 
     if @user.save
       @user.confirm!
       ignore_full = can?(:approve_when_full, @user)
       @user.approve!(ignore_full)
-      flash[:success] = t("users.create.success")
+      flash[:success] = msg.nil? ? t("users.create.success") : msg
       respond_to do |format|
         format.html { redirect_to manage_users_path }
       end

--- a/app/models/abilities/institution_admin_ability.rb
+++ b/app/models/abilities/institution_admin_ability.rb
@@ -24,7 +24,9 @@ module Abilities
            :give_recording_rights, :confirm], User do |target|
         target.institution.present? && target.institution.admins.include?(user)
       end
-      can [:new, :create], User
+      can [:new, :create], User do
+        !user.institution.full?
+      end
 
       # Institutional admins can access the manage lists of spaces and users in their institution
       can [:users, :spaces], :manage do

--- a/app/views/manage/users.html.haml
+++ b/app/views/manage/users.html.haml
@@ -2,7 +2,7 @@
 
 #manage
   .page-tabs.page-tabs-full
-    = link_to t('.new_user'), new_user_path, class: 'open-modal btn btn-primary btn-new-user'
+    = link_to t('.new_user'), new_user_path, class: 'open-modal btn btn-primary btn-new-user' if can?(:create, User.new)
     %label{ for: 'users_filter_text' }= t('.filter_results')
     = text_field_tag :users_filter_text, params[:q], placeholder: t('.filter_name_or_username'), 'data-load-url' =>  manage_users_path(partial: 1), :'data-target' => '#users-list', :'data-filter' => '#filter-total', class: 'resource-filter'
 

--- a/config/locales/en/_rnp_mconf.yml
+++ b/config/locales/en/_rnp_mconf.yml
@@ -66,6 +66,8 @@ en:
     menu:
       institutions: Institutions
       my_institution: "My Institution"
+    users:
+      create_without_record: "User created successfully, but the slots for record are full. Therefore, this user was created without the ability of record meetings."
   profiles:
     form:
       no_organization: "<no organization set>"

--- a/config/locales/pt-br/_rnp_mconf.yml
+++ b/config/locales/pt-br/_rnp_mconf.yml
@@ -67,6 +67,8 @@ pt-br:
     menu:
       institutions: Instituições
       my_institution: "Minha instituição"
+    users:
+      create_without_record: "Usuário criado com sucesso, mas as vagas para gravação estão cheias. Portanto, este usuário foi criado sem a capacidade de gravar reuniões."
   profiles:
     form:
       no_organization: "<nenhuma organização atribuída>"


### PR DESCRIPTION
Now global admins are able to create users even when the institution is already full (the same occur if the admin want to set if some user can record meetings).

The institution admins are only able to create users (and to approve users) if the institution is not already full. If an institution is not full yet but has no more slots for people that can record, the user is created but without the ability to record, even if it was checked when the user was created.

refs #1588 #1589