### PR TITLE
Feature1729 - Disk quota for institutions' recordings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ gem 'zip-zip' # will load compatibility for old rubyzip API.
 gem 'prism'
 
 gem 'fineuploader-rails', '~> 3.3'
+gem 'filesize'
 
 group :development do
   gem 'translate-rails3', :require => 'translate', :git => 'https://github.com/mconf/translate.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
     ffi-yajl (1.3.1)
       ffi (~> 1.5)
       libyajl2 (~> 1.2)
+    filesize (0.1.0)
     fineuploader-rails (3.3)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -569,6 +570,7 @@ DEPENDENCIES
   dotiw
   exception_notification (~> 4.0.0)
   factory_girl_rails
+  filesize
   fineuploader-rails (~> 3.3)
   font-awesome-rails (~> 4.1.0.0)
   fooldap

--- a/app/assets/stylesheets/app/manage/institutions.css.scss
+++ b/app/assets/stylesheets/app/manage/institutions.css.scss
@@ -16,4 +16,12 @@ body.manage.institutions {
     .btn { float: right; }
   }
 
+  .institution-disk {
+    padding-top: 10px;
+  }
+
+  .short-progress {
+    width: 20%;
+  }
+
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -165,7 +165,17 @@ class ApplicationController < ActionController::Base
   def bigbluebutton_create_options(room)
     ability = Abilities.ability_for(current_user)
 
-    can_record = ability.can?(:record_meeting, room)
+    # Check if institution disk quota was exceeded
+    #   Only runs if user/space has a institution, if they don't we can't know the correct quota
+    #   Also if there's permission to record without institution it's likely an admin and he should now what he's doing...
+    quota_exceeded = false
+    ins = @room.owner.institution
+    if ins.try(:exceeded_disk_quota?)
+      quota_exceeded = true
+      Rails.logger.info "RECORDING: '#{@room.name}' won't be able to record because disk quota for '#{ins.name}' was exceeded."
+    end
+
+    can_record = ability.can?(:record_meeting, room) && !quota_exceeded
     if current_site.webconf_auto_record
       # show the record button if the user has permissions to record
       { record: can_record }

--- a/app/controllers/institutions_controller.rb
+++ b/app/controllers/institutions_controller.rb
@@ -109,7 +109,7 @@ class InstitutionsController < ApplicationController
   end
 
   def institution_allowed_params
-    [ :acronym, :name, :user_limit, :can_record_limit, :identifier, :force_shib_login ]
+    [ :acronym, :name, :user_limit, :can_record_limit, :identifier, :force_shib_login, :recordings_disk_quota ]
   end
 
 

--- a/app/helpers/institutions_helper.rb
+++ b/app/helpers/institutions_helper.rb
@@ -1,0 +1,15 @@
+# This file is part of Mconf-Web, a web application that provides access
+# to the Mconf webconferencing system. Copyright (C) 2010-2012 Mconf
+#
+# This file is licensed under the Affero General Public License version
+# 3 or later. See the LICENSE file.
+
+module InstitutionsHelper
+
+  # Human readable file size approximating to
+  # the largest unit. Assumes 0 as the size if nil
+  def human_file_size bytes=0
+    Filesize.from("#{bytes} B").pretty
+  end
+
+end

--- a/app/models/concerns/update_institution_recordings_disk.rb
+++ b/app/models/concerns/update_institution_recordings_disk.rb
@@ -1,0 +1,14 @@
+module UpdateInstitutionRecordingsDisk
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :find_institution_and_update
+  end
+
+  def find_institution_and_update
+    space_or_user = self.room.owner
+
+    # Some user don't have institutions, tipically admins so this method could fail
+    space_or_user.institution.try(:update_recordings_disk_used!)
+  end
+end

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -111,8 +111,23 @@ class Institution < ActiveRecord::Base
     update_attribute(:recordings_disk_used, recordings.sum(:size))
   end
 
+  # Simple method to see if the recordings size exceeded the quota
+  # Don't treat this as an exact limit, because it will likely be exceeded
+  # by the last recording before the quota is still valid
   def exceeded_disk_quota?
+    return false if recordings_disk_quota.to_i == 0 # quota == 0 means unlimited
+
     recordings_disk_used.to_i >= recordings_disk_quota.to_i
+  end
+
+  # Returns a number ideally between 0..1 describing the
+  # disk usage ratio for the institution
+  # Could be > 1 if one big recording broke limit
+  # If the quota is unlimited (0) this value is also 0 but should be irrelevant
+  def disk_usage_ratio
+    return 0 if recordings_disk_quota.to_i == 0
+
+    recordings_disk_used.to_f / recordings_disk_quota.to_f
   end
 
   private

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -107,7 +107,7 @@ class Institution < ActiveRecord::Base
     room_ids = BigbluebuttonRoom.where(owner_id: spaces.with_disabled.ids, owner_type: 'Space').ids |
             BigbluebuttonRoom.where(owner_id: users.with_disabled.ids, owner_type: 'User').ids
 
-    recordings = BigbluebuttonRecording.where(room_id: room_ids).published()
+    recordings = BigbluebuttonRecording.where(room_id: room_ids)
     update_attribute(:recordings_disk_used, recordings.sum(:size))
   end
 

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -101,6 +101,16 @@ class Institution < ActiveRecord::Base
     p.role.name unless p.nil? or p.role.nil?
   end
 
+  # Call this to query all recordings belonging to this institution (users and spaces)
+  # and get a sum of their sizes in the 'recordings_disk_used' field
+  def update_recordings_disk_used!
+    room_ids = BigbluebuttonRoom.where(owner_id: spaces.with_disabled.ids, owner_type: 'Space').ids |
+            BigbluebuttonRoom.where(owner_id: users.with_disabled.ids, owner_type: 'User').ids
+
+    recordings = BigbluebuttonRecording.where(room_id: room_ids).published()
+    update_attribute(:recordings_disk_used, recordings.sum(:size))
+  end
+
   def exceeded_disk_quota?
     recordings_disk_used.to_i >= recordings_disk_quota.to_i
   end
@@ -112,7 +122,7 @@ class Institution < ActiveRecord::Base
 
       if is_number?(self.recordings_disk_quota)
         # express size in bytes if a number without units was present
-        write_attribute(:recordings_disk_quota, Filesize.from("#{self.recordings_disk_quota} B"))
+        write_attribute(:recordings_disk_quota, Filesize.from("#{self.recordings_disk_quota} B").to_i)
       elsif is_filesize?(self.recordings_disk_quota)
         write_attribute(:recordings_disk_quota, Filesize.from(self.recordings_disk_quota).to_i)
       end

--- a/app/views/custom_bigbluebutton_recordings/_form.html.haml
+++ b/app/views/custom_bigbluebutton_recordings/_form.html.haml
@@ -19,6 +19,7 @@
   = f.input :available, :as => :boolean, :disabled => !editing
   = f.input :start_time, :disabled => !editing
   = f.input :end_time, :disabled => !editing
+  = f.input :size, :disabled => true, input_html: { value: human_file_size(@recording.size) }
 
   %label= BigbluebuttonRecording.human_attribute_name(:metadata)
   #recording-metadata

--- a/app/views/institutions/_form.html.haml
+++ b/app/views/institutions/_form.html.haml
@@ -8,6 +8,8 @@
       = f.input :can_record_limit
       = f.input :identifier
       = f.input :force_shib_login
+      = f.input :recordings_disk_quota, as: :string, input_html: { value: human_file_size(@institution.recordings_disk_quota) }
+      = f.input :recordings_disk_used, :disabled => true, input_html: { value: human_file_size(@institution.recordings_disk_used) }
 
   .modal-footer
     = f.button :wrapped, :cancel_modal => true, :value => button_name, :class => "btn btn-primary"

--- a/app/views/manage/_institution.html.haml
+++ b/app/views/manage/_institution.html.haml
@@ -25,5 +25,10 @@
 
       - if institution.recordings_disk_quota.to_i != 0
         .institution-disk
-          = used = t('.disk_used', used: human_file_size(institution.recordings_disk_used), quota: human_file_size(institution.recordings_disk_quota))
-          %meter{min: "0", max: "1.0", low: "0.2", high: "0.9", optimum: "0.5" , value: institution.disk_usage_ratio, title: used}
+
+          = t('.recordings_disk_used')
+          %p.progress-label
+            = t('.disk_used', used: human_file_size(institution.recordings_disk_used), quota: human_file_size(institution.recordings_disk_quota))
+
+          .progress.short-progress
+            .bar{role: 'progressbar', :'aria-valuemin' => '0', :'aria-valuemax' => '1.0', :'aria-valuenow' => institution.disk_usage_ratio, style: "width: #{(institution.disk_usage_ratio * 100)}%;"}

--- a/app/views/manage/_institution.html.haml
+++ b/app/views/manage/_institution.html.haml
@@ -22,3 +22,8 @@
           = '(' + t('.can_record_limit', :limit => institution.can_record_limit) + ')'
       .institution-spaces
         = link_to t('.spaces', :count => institution.spaces.count).capitalize, spaces_institution_path(institution)
+
+      - if institution.recordings_disk_quota.to_i != 0
+        .institution-disk
+          = used = t('.disk_used', used: human_file_size(institution.recordings_disk_used), quota: human_file_size(institution.recordings_disk_quota))
+          %meter{min: "0", max: "1.0", low: "0.2", high: "0.9", optimum: "0.5" , value: institution.disk_usage_ratio, title: used}

--- a/config/initializers/bigbluebutton_rails.rb
+++ b/config/initializers/bigbluebutton_rails.rb
@@ -70,4 +70,8 @@ Rails.application.config.to_prepare do
     }
   end
 
+  BigbluebuttonRecording.instance_eval do
+    include UpdateInstitutionRecordingsDisk
+  end
+
 end

--- a/config/locales/en/_rnp_mconf.yml
+++ b/config/locales/en/_rnp_mconf.yml
@@ -59,6 +59,7 @@ en:
       can_record_limit: "maximum: %{limit}"
       destroy: "Remove institution"
       disk_used: "%{used} used of %{quota}"
+      recordings_disk_used: Recordings disk used
       no_user_limit: "no maximum"
       users:
         zero: 0 members

--- a/config/locales/en/_rnp_mconf.yml
+++ b/config/locales/en/_rnp_mconf.yml
@@ -58,6 +58,7 @@ en:
         other: "%{count} members can record"
       can_record_limit: "maximum: %{limit}"
       destroy: "Remove institution"
+      disk_used: "%{used} used of %{quota}"
       no_user_limit: "no maximum"
       users:
         zero: 0 members

--- a/config/locales/en/_rnp_simple_form.yml
+++ b/config/locales/en/_rnp_simple_form.yml
@@ -4,6 +4,8 @@ en:
       institution:
         acronym: "Adding an acronym will help users find the right institution when registering."
         can_record_limit: "Optional. Enter a number to limit how many users can record meetings in this intitution. Leave it empty to set no limits."
+        recordings_disk_quota: "Maximum disk space that can be used by recordings from this institution"
+        recordings_disk_used: "Current disk space being used by recordings from this institution"
         force_shib_login: "When enabled the user will only be allowed to login via federation"
         identifier: "Identifier to match users that will belong to this institution. You can use multiple values, one per line, as regular expression. The comparisons are case-insensitive and the strings are trimmed. If a user is identified in the federation as \"user@sub.institution.org\", for example, one possible value to match this user would be \"(.*\\.)?institution\\.org\", that would match any subdomain of an institution."
         user_limit: "Optional. Enter a number to limit how many users can be part of this institution. Leave it empty to set no limits."

--- a/config/locales/pt-br/_rnp_mconf.yml
+++ b/config/locales/pt-br/_rnp_mconf.yml
@@ -61,6 +61,7 @@ pt-br:
         other: "%{count} membros podem gravar"
       can_record_limit: "máximo: %{limit}"
       destroy: "Remover instituição"
+      disk_used: "%{used} ocupados de %{quota}"
       no_user_limit: "sem limite"
       users:
         zero: 0 membros

--- a/config/locales/pt-br/_rnp_mconf.yml
+++ b/config/locales/pt-br/_rnp_mconf.yml
@@ -62,6 +62,7 @@ pt-br:
       can_record_limit: "máximo: %{limit}"
       destroy: "Remover instituição"
       disk_used: "%{used} ocupados de %{quota}"
+      recordings_disk_used: Ocupação do disco por gravações
       no_user_limit: "sem limite"
       users:
         zero: 0 membros

--- a/config/locales/pt-br/_rnp_mconf.yml
+++ b/config/locales/pt-br/_rnp_mconf.yml
@@ -4,6 +4,8 @@ pt-br:
       institution:
         acronym: Sigla
         can_record_limit: Usuários que podem gravar
+        recordings_disk_quota: Quota de disco para gravações
+        recordings_disk_used: Espaço ocupado por gravações
         force_shib_login: Somente login via federação
         name: Nome
         user_limit: Máximo de membros

--- a/config/locales/pt-br/_rnp_simple_form.yml
+++ b/config/locales/pt-br/_rnp_simple_form.yml
@@ -4,6 +4,8 @@ pt-br:
       institution:
         acronym: "Adicionar uma sigla ajuda os usuários a encontrarem a instituição correta ao se registrar."
         can_record_limit: "Opcional. Informe um número caso deseje limitar o número de membros que podem gravar reuniões nesta instituição. Deixe em branco para não limitar o número de membros."
+        recordings_disk_quota: "Limite máximo de espaço no servidor que pode ser ocupado por gravações desta instituição."
+        recordings_disk_used: "Espaço em disco atualmente ocupado por gravações dessa instituição"
         force_shib_login: "Quando habilitado o usuário só poderá se logar através da federação"
         identifier: "Identificador usado para encontrar os usuários que pertencerão a esta instituição. Você pode usar múltiplos valores, um por linha, como expressões regulares. As comparações são \"case-insensitive\" e espaços são removidos do início e fim. Se um usuário é identificado por \"eu@sub.instituicao.org\", por exemplo, um dos valores para localizar este usuário seria \"(.*\\.)?instituicao\\.org\", que funcionaria para qualquer subdomínio de uma instituição."
         user_limit: "Opcional. Informe um número caso deseje limitar o número de usuários que podem fazer parte desta instituição. Deixe em branco para não limitar o número de membros."

--- a/db/migrate/20150810204647_add_recordings_disk_quota_and_recordings_disk_used_to_institutions.rb
+++ b/db/migrate/20150810204647_add_recordings_disk_quota_and_recordings_disk_used_to_institutions.rb
@@ -1,0 +1,6 @@
+class AddRecordingsDiskQuotaAndRecordingsDiskUsedToInstitutions < ActiveRecord::Migration
+  def change
+    add_column :institutions, :recordings_disk_used, :string, default: 0
+    add_column :institutions, :recordings_disk_quota, :string, default: 0
+  end
+end

--- a/db/migrate/20150811195101_bigbluebutton_rails_to201.rb
+++ b/db/migrate/20150811195101_bigbluebutton_rails_to201.rb
@@ -1,5 +1,5 @@
 class BigbluebuttonRailsTo201 < ActiveRecord::Migration
   def change
-    add_column :bigbluebutton_recordings, :size, :string
+    add_column :bigbluebutton_recordings, :size, :integer, default: 0
   end
 end

--- a/db/migrate/20150811195101_bigbluebutton_rails_to201.rb
+++ b/db/migrate/20150811195101_bigbluebutton_rails_to201.rb
@@ -1,0 +1,5 @@
+class BigbluebuttonRailsTo201 < ActiveRecord::Migration
+  def change
+    add_column :bigbluebutton_recordings, :size, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 20150811195101) do
     t.datetime "updated_at"
     t.text     "description"
     t.integer  "meeting_id"
-    t.string   "size"
+    t.integer  "size",        default: 0
   end
 
   add_index "bigbluebutton_recordings", ["recordid"], name: "index_bigbluebutton_recordings_on_recordid", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150416210956) do
+ActiveRecord::Schema.define(version: 20150811195101) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 20150416210956) do
     t.datetime "updated_at"
     t.text     "description"
     t.integer  "meeting_id"
+    t.string   "size"
   end
 
   add_index "bigbluebutton_recordings", ["recordid"], name: "index_bigbluebutton_recordings_on_recordid", unique: true, using: :btree
@@ -175,6 +176,8 @@ ActiveRecord::Schema.define(version: 20150416210956) do
     t.integer  "can_record_limit"
     t.text     "identifier"
     t.boolean  "force_shib_login", default: false
+    t.string   "recordings_disk_used",  default: "0"
+    t.string   "recordings_disk_quota", default: "0"
   end
 
   create_table "invitations", force: true do |t|

--- a/lib/tasks/db/populate.rake
+++ b/lib/tasks/db/populate.rake
@@ -281,6 +281,7 @@ namespace :db do
         recording.start_time = @created_at_start..Time.now
         recording.end_time = recording.start_time + rand(5).hours
         recording.description = Populator.words(5..8)
+        recording.size = rand((20*1024**2)..(500*1024**2)) #size ranging from 20Mb to 500Mb
 
         # Recording metadata
         BigbluebuttonMetadata.populate 0..3 do |meta|

--- a/spec/models/bigbluebutton_recording_spec.rb
+++ b/spec/models/bigbluebutton_recording_spec.rb
@@ -8,6 +8,32 @@ require "spec_helper"
 
 describe BigbluebuttonRecording do
 
+  describe "update institution disk size after CREATING a recording" do
+    let(:owner) { FactoryGirl.create(:space) }
+    let(:room) { FactoryGirl.create(:bigbluebutton_room, owner: owner) }
+    let!(:recording) { FactoryGirl.create(:bigbluebutton_recording, room: room, server: room.server) }
+
+    before {
+      allow(owner.institution).to receive(:update_recordings_disk_used!)
+    }
+
+    it { owner.institution.recordings_disk_used.to_i.should eq(0) }
+  end
+
+  describe "update institution disk size after UPDATING a recording" do
+    let(:owner) { FactoryGirl.create(:space) }
+    let(:room) { FactoryGirl.create(:bigbluebutton_room, owner: owner) }
+    let!(:recording) { FactoryGirl.create(:bigbluebutton_recording, room: room, server: room.server) }
+
+    before {
+      allow(owner.institution).to receive(:update_recordings_disk_used!).at_least(:once).and_call_original
+      recording.update_attributes size: 100
+    }
+
+    it { owner.institution.recordings_disk_used.to_i.should eq(100) }
+  end
+
+
   # This is a model from BigbluebuttonRails, but we have permissions set in cancan for it,
   # so we test them here.
   describe "abilities", :abilities => true do
@@ -32,7 +58,7 @@ describe BigbluebuttonRecording do
       end
 
       context "in a public space" do
-        let(:space) { FactoryGirl.create(:space, :public => true) }
+        let(:space) { FactoryGirl.create(:space_with_associations, :public => true) }
         let(:target) { FactoryGirl.create(:bigbluebutton_recording, :room => space.bigbluebutton_room) }
 
         context "he doesn't belong to" do

--- a/spec/models/institution_spec.rb
+++ b/spec/models/institution_spec.rb
@@ -115,6 +115,59 @@ describe Institution do
   it "#can_record_full?"
   it "#admins"
 
+  describe "#disk_usage_ratio and #exceeded_disk_quota?" do
+    let(:institution) { FactoryGirl.create(:institution, recordings_disk_quota: quota, recordings_disk_used: used) }
+
+    context '100%' do
+      let(:quota) { 1001 }
+      let(:used) { 1001 }
+
+      it { institution.disk_usage_ratio.should eq(1) }
+      it { institution.exceeded_disk_quota?.should be(true) }
+    end
+
+    context '50%' do
+      let(:quota) { 500 }
+      let(:used) { 250 }
+
+      it { institution.disk_usage_ratio.should eq(0.5) }
+      it { institution.exceeded_disk_quota?.should be(false) }
+    end
+
+    context '20%' do
+      let(:quota) { 5000 }
+      let(:used) { 1000 }
+
+      it { institution.disk_usage_ratio.should eq(0.2) }
+      it { institution.exceeded_disk_quota?.should be(false) }
+    end
+
+    context '0%' do
+      let(:quota) { 1001 }
+      let(:used) { 0 }
+
+      it { institution.disk_usage_ratio.should eq(0) }
+      it { institution.exceeded_disk_quota?.should be(false) }
+    end
+
+    context '120%' do
+      let(:quota) { 5000 }
+      let(:used) { 6000 }
+
+      it { institution.disk_usage_ratio.should eq(1.2) }
+      it { institution.exceeded_disk_quota?.should be(true) }
+    end
+
+    context 'unlimited quota' do
+      let(:quota) { 0 }
+      let(:used) { 1001 }
+
+      it { institution.disk_usage_ratio.should eq(0) }
+      it { institution.exceeded_disk_quota?.should be(false) }
+    end
+
+  end
+
   describe "#recordings_disk_quota=" do
     let(:institution) { FactoryGirl.create(:institution) }
 


### PR DESCRIPTION
Institutions now have `recordings_disk_quota` and `recordings_disk_used` attributes and some methods that use them.

  * update_recordings_disk_used! : This method queries all recordings belonging to this institution and sums their size into the `recordings_disk_used` column
  * exceeded_disk_quota? : Returns true or false indicating if the institution has exceeded their disk quota. If the quota is 0 it will always return false.
  * disk_usage_ratio : Returns a value between 0..1 indicating how much of the disk quota is used for this institution

Still missing notifications for when user can't record because of a quota http://dev.mconf.org/redmine/issues/1736 (I'll keep updating this PR here)