### PR TITLE
Bug1797 - Institution space moderation flags override site behavior

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -366,7 +366,7 @@ class SpacesController < ApplicationController
   end
 
   def require_approval?
-    @space.institution.try(:require_space_approval?) || current_site.require_space_approval?
+    @space.require_approval?
   end
 
   allow_params_for :space

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -366,7 +366,7 @@ class SpacesController < ApplicationController
   end
 
   def require_approval?
-    @space.institution.try(:require_space_approval?) && current_site.require_space_approval?
+    @space.institution.try(:require_space_approval?) || current_site.require_space_approval?
   end
 
   allow_params_for :space

--- a/app/models/abilities/member_ability_rnp.rb
+++ b/app/models/abilities/member_ability_rnp.rb
@@ -16,7 +16,13 @@ module Abilities
       can [:select], Institution
 
       # Users can't create space if their institution forbids it
-      cannot [:create, :new], Space if user.institution.try(:forbid_user_space_creation?)
+      if user.institution
+        if user.institution.forbid_user_space_creation?
+          cannot [:create, :new], Space
+        else
+          can [:create, :new], Space, disabled: false
+        end
+      end
     end
 
   end

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -66,7 +66,6 @@ class Space < ActiveRecord::Base
   end
 
   belongs_to :institution
-  # attr_accessible :institution, :institution_id
 
   # for the associated BigbluebuttonRoom
   # attr_accessible :bigbluebutton_room_attributes
@@ -81,7 +80,11 @@ class Space < ActiveRecord::Base
     # Space institution or creator's institution (when called from create)
     institution = self.institution || created_by.try(:institution)
 
-    institution.try(:require_space_approval?) || Site.current.require_space_approval?
+    if institution
+      institution.require_space_approval?
+    else
+      Site.current.require_space_approval?
+    end
   end
 
   validates :description, :presence => true

--- a/app/views/layouts/_spaces_page_title.html.haml
+++ b/app/views/layouts/_spaces_page_title.html.haml
@@ -23,7 +23,7 @@
       %span.user-is-member
         = icon_is_member
         = t(".is_member")
-    - if current_site.require_space_approval? && !@space.approved?
+    - if @space.require_approval? && !@space.approved?
       .resource-waiting-tooltip
         = icon_waiting_moderation
         = t("_other.not_approved.text")

--- a/app/views/manage/_enabled_space.html.haml
+++ b/app/views/manage/_enabled_space.html.haml
@@ -23,7 +23,7 @@
       %span.institution-name
         = link_to space.institution.full_name, spaces_institution_path(space.institution)
 
-    - if current_site.require_space_approval? && !space.approved?
+    - if space.require_approval? && !space.approved?
       .resource-waiting-moderation-tooltip
         = icon_waiting_moderation
         = t("_other.not_approved.text")

--- a/app/views/spaces/_unified_space.html.haml
+++ b/app/views/spaces/_unified_space.html.haml
@@ -40,7 +40,7 @@
               = t(".private")
               = t('.with_members', :count => space.users.size)
 
-          - if current_site.require_space_approval? && !space.approved?
+          - if space.require_approval? && !space.approved?
             .space-waiting-moderation.resource-visibility.small
               = icon_waiting_moderation
               = t("_other.not_approved.text")

--- a/spec/features/spaces/access_denied_errors_spec.rb
+++ b/spec/features/spaces/access_denied_errors_spec.rb
@@ -14,7 +14,7 @@ feature 'User hits access denied errors' do
 
   context 'while accessing a public space which is unapproved' do
     let(:user) { FactoryGirl.create(:user) }
-    let(:space) { FactoryGirl.create(:space, approved: false, :public => true) }
+    let(:space) { FactoryGirl.create(:space, approved: false, institution: nil, :public => true) }
     before { Site.current.update_attributes(require_space_approval: true) }
     subject { page }
 
@@ -56,7 +56,7 @@ feature 'User hits access denied errors' do
       login_as(user, scope: :user)
     }
     let(:user) { FactoryGirl.create(:user) }
-    let(:space) { FactoryGirl.create(:space_with_associations, approved: false, public: false) }
+    let(:space) { FactoryGirl.create(:space_with_associations, institution: nil, approved: false, public: false) }
     subject { page }
 
     context 'as a member' do
@@ -81,7 +81,7 @@ feature 'User hits access denied errors' do
 
   context 'while accessing a private space' do
     let(:user) { FactoryGirl.create(:user) }
-    let(:space) { FactoryGirl.create(:space_with_associations, :public => false) }
+    let(:space) { FactoryGirl.create(:space_with_associations, institution: nil, :public => false) }
     subject { page }
 
     context 'and is logged out' do
@@ -115,7 +115,7 @@ feature 'User hits access denied errors' do
 
   context 'while accessing the edit page of a public space' do
     let(:user) { FactoryGirl.create(:user) }
-    let(:space) { FactoryGirl.create(:space_with_associations, public: true) }
+    let(:space) { FactoryGirl.create(:space_with_associations, institution: nil, public: true) }
     subject { page }
 
     context 'and is logged out' do

--- a/spec/features/spaces/creating_a_space_spec.rb
+++ b/spec/features/spaces/creating_a_space_spec.rb
@@ -24,7 +24,7 @@ def create_space_from_attrs attrs
 end
 
 feature "Creating a space" do
-  let(:user) { FactoryGirl.create(:user) }
+  let(:user) { FactoryGirl.create(:user, institution: nil) }
 
   context "as public" do
     let(:attrs) { FactoryGirl.attributes_for(:space, public: true) }

--- a/spec/features/spaces/space_admin_in_an_unapproved_space_spec.rb
+++ b/spec/features/spaces/space_admin_in_an_unapproved_space_spec.rb
@@ -12,7 +12,7 @@ describe 'Space admin in an unapproved space' do
 
   context "should not see these links" do
     let(:user) { FactoryGirl.create(:user) }
-    let(:space) { FactoryGirl.create(:space_with_associations, approved: false, repository: true) }
+    let(:space) { FactoryGirl.create(:space_with_associations, institution: nil, approved: false, repository: true) }
 
     before {
       Site.current.update_attributes(require_space_approval: true)
@@ -47,7 +47,7 @@ describe 'Space admin in an unapproved space' do
 
   context "make sure an admin on an approved space sees all the links" do
     let(:user) { FactoryGirl.create(:user) }
-    let(:space) { FactoryGirl.create(:space_with_associations, approved: true, repository: true) }
+    let(:space) { FactoryGirl.create(:space_with_associations, institution: nil, approved: true, repository: true) }
 
     before {
       space.add_member!(user, 'Admin')

--- a/spec/support/shared_examples/spaces.rb
+++ b/spec/support/shared_examples/spaces.rb
@@ -40,9 +40,9 @@ shared_examples_for "assigns @spaces_examples" do
   context "returns only approved spaces if the site requires approval" do
     before {
       Site.current.update_attributes(require_space_approval: true)
-      @s1 = FactoryGirl.create(:space, approved: false)
-      @s2 = FactoryGirl.create(:space, approved: true)
-      @s3 = FactoryGirl.create(:space, approved: false)
+      @s1 = FactoryGirl.create(:space, institution: nil, approved: false)
+      @s2 = FactoryGirl.create(:space, institution: nil, approved: true)
+      @s3 = FactoryGirl.create(:space, institution: nil, approved: false)
       do_action
     }
     it { assigns(:spaces_examples).count.should be(1) }

--- a/spec/workers/space_notifications_worker_spec.rb
+++ b/spec/workers/space_notifications_worker_spec.rb
@@ -23,7 +23,7 @@ describe SpaceNotificationsWorker do
       context "notifies admins when spaces need approval" do
 
         context "for multiple global admins and a space with no institution" do
-          let(:space) { FactoryGirl.create(:space, approved: false) }
+          let(:space) { FactoryGirl.create(:space, institution: nil, approved: false) }
           let!(:space_admin) { FactoryGirl.create(:user, institution: nil) }
 
           let!(:admin1) { FactoryGirl.create(:superuser) }
@@ -43,8 +43,8 @@ describe SpaceNotificationsWorker do
         end
 
         context "for multiple spaces with institutions" do
-          let(:space_admin) { FactoryGirl.create(:user) }
-          let(:institution) { space_admin.institution }
+          let(:institution) { FactoryGirl.create(:institution, require_space_approval: true) }
+          let(:space_admin) { FactoryGirl.create(:user, institution: institution) }
 
           let(:space1) { FactoryGirl.create(:space, institution: institution, approved: false) }
           let(:space2) { FactoryGirl.create(:space, institution: institution, approved: false) }
@@ -70,9 +70,9 @@ describe SpaceNotificationsWorker do
         end
 
         context "for multiple spaces some with institutions, some don't" do
-          let!(:space_admin) { FactoryGirl.create(:user) }
+          let(:institution) { FactoryGirl.create(:institution, require_space_approval: true) }
+          let!(:space_admin) { FactoryGirl.create(:user, institution: institution) }
           let!(:space_admin_no_inst) { FactoryGirl.create(:user, institution: nil) }
-          let(:institution) { space_admin.institution }
 
           let(:space1) { FactoryGirl.create(:space, institution: institution, approved: false) }
           let(:space2) { FactoryGirl.create(:space, institution: nil, approved: false) }
@@ -100,8 +100,8 @@ describe SpaceNotificationsWorker do
 
         context "ignores space not approved but that already had their notification sent" do
           let!(:admin) { FactoryGirl.create(:user) }
-          let!(:space1) { FactoryGirl.create(:space, approved: false) }
-          let!(:space2) { FactoryGirl.create(:space, approved: false) }
+          let!(:space1) { FactoryGirl.create(:space, institution: nil, approved: false) }
+          let!(:space2) { FactoryGirl.create(:space, institution: nil, approved: false) }
           before {
             space1.add_member!(admin, 'Admin')
             space1.new_activity('create', admin)


### PR DESCRIPTION
Had to change some tests and set space.institution => nil, because now institution flags interfere on the normal tests where we wanted to test only space.require_approval? and forbidden space creation.