### PR TITLE
Institutional admin manage recordings #81

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -624,6 +624,3 @@ DEPENDENCIES
   yui-compressor
   zip-zip
   zonebie
-
-BUNDLED WITH
-   1.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -624,3 +624,6 @@ DEPENDENCIES
   yui-compressor
   zip-zip
   zonebie
+
+BUNDLED WITH
+   1.13.1

--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -95,7 +95,17 @@ class ManageController < ApplicationController
 
   def recordings
     words = params[:q].try(:split, /\s+/)
-    query = BigbluebuttonRecording.search_by_terms(words).search_order
+
+    query = if current_user.superuser?
+              BigbluebuttonRecording.search_by_terms(words)
+            else
+              # institutional admins search only inside their institution
+              # can pass "true" to get private data since it's only for users
+              # that belong to the institution
+              current_user.institution.recordings.search_by_terms(words)
+            end
+
+    query = query.search_order
 
     [:published, :available].each do |filter|
       if !params[filter].nil?

--- a/app/models/abilities/institution_admin_ability.rb
+++ b/app/models/abilities/institution_admin_ability.rb
@@ -32,8 +32,8 @@ module Abilities
         user.institution.present? && !user.institution.full?
       end
 
-      # Institutional admins can access the manage lists of spaces and users in their institution
-      can [:users, :spaces], :manage do
+      # Institutional admins can access the manage lists of recordings, spaces and users in their institution
+      can [:users, :spaces, BigbluebuttonRecording, :recordings], :manage do
         !user.institution.nil? && user.institution.admins.include?(user)
       end
 
@@ -46,6 +46,13 @@ module Abilities
       # Institutional admins can edit their institution's users
       can [:show, :edit, :update], Profile do |profile|
         !profile.user.institution.nil? && profile.user.institution.admins.include?(user)
+      end
+
+      # Institutional admins can edit their institution's recordings
+      can [:show, :edit, :update, :manage], BigbluebuttonRecording do |recording|
+        if recording.room.present? && recording.room.owner.present?
+          !recording.room.owner.institution.nil? && recording.room.owner.institution.admins.include?(user)
+        end
       end
 
       # Can create no matter if the site has creation disabled

--- a/app/views/manage/_menu.html.haml
+++ b/app/views/manage/_menu.html.haml
@@ -15,7 +15,7 @@
       %li{ :class => "#{'selected' if params[:controller] == 'manage' && params[:action] == 'spaces'}" }
         = link_to t('.spaces'), manage_spaces_path
 
-    - if can?(:manage, BigbluebuttonRecording)
+    - if can?(BigbluebuttonRecording, :manage)
       %li{ :class => "#{'selected' if params[:controller] == 'manage' && params[:action] == 'recordings'}" }
         = link_to t('.recordings'), manage_recordings_path
 

--- a/app/views/manage/_menu.html.haml
+++ b/app/views/manage/_menu.html.haml
@@ -15,7 +15,7 @@
       %li{ :class => "#{'selected' if params[:controller] == 'manage' && params[:action] == 'spaces'}" }
         = link_to t('.spaces'), manage_spaces_path
 
-    - if can?(BigbluebuttonRecording, :manage)
+    - if can?(:manage, BigbluebuttonRecording)
       %li{ :class => "#{'selected' if params[:controller] == 'manage' && params[:action] == 'recordings'}" }
         = link_to t('.recordings'), manage_recordings_path
 


### PR DESCRIPTION
Added abilities so that the Institutional Admin is able to see the manage recordings tab and manage recordings from his institution.

Added abilities specs to the Institutional Admin abilities over recordings.
Added specs on Institutional Admin access to recordings on manage.

Resolves #81 