### PR TITLE
Fixed issue on institution filtering by admin who is also institution admin

### DIFF
--- a/app/controllers/manage_controller.rb
+++ b/app/controllers/manage_controller.rb
@@ -42,7 +42,8 @@ class ManageController < ApplicationController
     end
 
     # ignore this filter for institution admins
-    if params[:institutions].present? && !current_user.institution_admin?
+    # here we add the superuser? check to avoid institutional admins to use this filter unless they are also global admin
+    if params[:institutions].present? && current_user.superuser?
       permalinks = params[:institutions].split(',')
       ids = Institution.where(permalink: permalinks).ids
       users = Permission.where(subject_type: 'Institution', subject_id: ids).pluck(:user_id)

--- a/app/views/manage/users.html.haml
+++ b/app/views/manage/users.html.haml
@@ -9,7 +9,7 @@
       = text_field_tag :users_filter_text, params[:q], placeholder: t('.filter_name_or_username'), 'data-load-url' =>  manage_users_path, :'data-target' => '#users-list', :'data-filter' => '#filter-total', class: 'resource-filter'
 
     .search-institution
-      - unless current_user.institution_admin?
+      - unless (current_user.institution_admin? && !current_user.superuser?)
         .institution-filter
           = text_field_tag :institutions, '', placeholder: t('.filter_institution'), class: 'string'
 

--- a/spec/controllers/manage_controller_spec.rb
+++ b/spec/controllers/manage_controller_spec.rb
@@ -275,6 +275,16 @@ describe ManageController do
             let(:params) { {institutions: 'inexistent-institution,inexistent-institutions2'} }
             it { assigns(:users).count.should be(0) }
           end
+
+          context "filters by institution even when admin is also institution admin" do
+            before { institution.add_member!(user, 'Admin') }
+            before { sign_in user }
+            let(:institutions_array) { [institution, institution2] }
+            let(:params) { {institutions: institutions} }
+
+            it { assigns(:users).count.should be(1) }
+            it { assigns(:users).should include(users[0]) }
+          end
         end
 
         context "mixed params" do
@@ -493,6 +503,13 @@ describe ManageController do
 
           it { assigns(:users).count.should be(2) }
           it { assigns(:users).should include(users[0], users[4]) }
+        end
+
+        context "fails to filter by institution" do
+          let(:params) { {institutions: "another institution"} }
+
+          it { assigns(:users).count.should be(5) }
+          it { assigns(:users).should include(users[0], users[1], users[3], users[4], users[5]) }
         end
       end
 


### PR DESCRIPTION
Fixed issue that would not allow a global admin to filter /manage/users by institution if he was also an institutional admin
Fixes #90 