### PR TITLE
Removed duplicate content from webconf invite message

### DIFF
--- a/app/mailers/views/web_conference_mailer/invitation_email.html.haml
+++ b/app/mailers/views/web_conference_mailer/invitation_email.html.haml
@@ -2,10 +2,6 @@
   %p= t('.message.header', sender: @invitation.sender.full_name, email_sender: @invitation.sender.email).html_safe
   = render "shared/invitation_email"
 
-  %p= t('.message.quality_warn')
-  %p= t('.message.user_manual')
-  %p= t('.message.rnp_contact')
-
   - if @invitation.target.dial_number.present?
     .field
       %label= t('.message.dial_number') + ':'


### PR DESCRIPTION
The content was moved from the top to bottom of the e-mail
Content was likely duplicated on merge